### PR TITLE
退出登录加入二次确认对话框

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { noticeOpen } from '../utils/dialog'
+import { noticeOpen, dialogOpen } from '../utils/dialog'
 import { isLogin } from '../utils/authority'
 import { useUserStore } from '../store/userStore'
 import { usePlayerStore } from '../store/playerStore'
@@ -47,7 +47,10 @@ const userLogout = async () => {
 }
 const handleAuthOptionClick = () => {
     if (isLogin()) {
-        userLogout()
+        userStore.appOptionShow = false
+        dialogOpen('确定退出', '退出后需要重新登录才能使用账号相关功能，确定退出吗？', flag => {
+            if (flag) userLogout()
+        })
         return
     }
     userStore.appOptionShow = false

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -539,6 +539,15 @@ const userLogout = async () => {
     router.push('/')
     noticeOpen('已退出账号', 2)
 }
+const confirmLogout = () => {
+    if (!isLogin()) {
+        noticeOpen('您已退出账号', 2)
+        return
+    }
+    dialogOpen('确定退出', '退出后需要重新登录才能使用账号相关功能，确定退出吗？', flag => {
+        if (flag) userLogout()
+    })
+}
 const save = () => {
     selectedShortcut.value = null
     setCustomFont()
@@ -620,7 +629,7 @@ const clearFmRecent = () => {
                         </div>
                     </div>
                 </div>
-                <div class="logout" @click="userLogout()">
+                <div class="logout" @click="confirmLogout()">
                     <span>退出</span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- 复用项目内现有的 GlobalDialog 组件，为两处退出登录入口加上二次确认弹窗，避免误操作
  - 设置页 "退出" 按钮 (src/views/Settings.vue)
  - 用户头像下拉菜单中的 "退出登录" 项 (src/views/Home.vue)
- 弹窗文案与项目内 "确定开启" 类确认弹窗保持一致；用户菜单入口在弹窗弹出前先关闭下拉菜单，避免遮挡

## Test plan
- [ ] 设置页点击 "退出" 按钮 → 弹出 "确定退出" 确认对话框；点 "取消" 不退出，点 "确认" 才执行退出
- [ ] 用户头像下拉菜单点击 "退出登录" 项 → 下拉菜单关闭并弹出确认对话框，行为同上
- [ ] 未登录状态下点击两个入口，均不弹出确认框，仅显示 "您已退出账号" 通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)